### PR TITLE
Bump dlist upper bound to 0.9

### DIFF
--- a/wavefront.cabal
+++ b/wavefront.cabal
@@ -42,7 +42,7 @@ library
 
   build-depends:       base         >= 4.8  && < 4.9
                      , attoparsec   >= 0.13 && < 0.14
-                     , dlist        >= 0.7  && < 0.8
+                     , dlist        >= 0.7  && < 0.9
                      , filepath     >= 1.4  && < 1.5
                      , mtl          >= 2.2  && < 2.3
                      , text         >= 1.2  && < 1.3


### PR DESCRIPTION
I just released [`dlist-0.8`](https://github.com/spl/dlist/releases/tag/v0.8). I didn't test this change to `wavefront`, but I don't think it will be break anything.