### PR TITLE
raise dependency barrier for base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 0.7.1
+
+- Allow missing group names.
+- Spaced object and material names are now supported.
+
 #### 0.7.0.2
 
 - Added support for `vector-0.12.0.0`.

--- a/wavefront.cabal
+++ b/wavefront.cabal
@@ -1,5 +1,5 @@
 name:                wavefront
-version:             0.7.0.3
+version:             0.7.1
 synopsis:            Wavefront OBJ loader
 description:         A Wavefront OBJ loader. Currently supports polygonal information. More could
                      be added if needed (like curves and surface) if people contribute. Feel free


### PR DESCRIPTION
For using ghc 8.2.1 you need a higher base version.