### PR TITLE
Relax version bounds

### DIFF
--- a/wavefront.cabal
+++ b/wavefront.cabal
@@ -40,14 +40,14 @@ library
 
   default-extensions:  OverloadedStrings
 
-  build-depends:       base         >= 4.8  && < 4.14
-                     , attoparsec   >= 0.13 && < 0.14
-                     , dlist        >= 0.7  && < 0.9
+  build-depends:       base         >= 4.8  && < 4.18
+                     , attoparsec   >= 0.13 && < 0.15
+                     , dlist        >= 0.7  && < 1.1
                      , filepath     >= 1.4  && < 1.5
-                     , mtl          >= 2.2  && < 2.3
-                     , text         >= 1.2  && < 1.3
-                     , transformers >= 0.4  && < 0.6
-                     , vector       >= 0.11 && < 0.13
+                     , mtl          >= 2.2  && < 2.4
+                     , text         >= 1.2  && < 2.1
+                     , transformers >= 0.4  && < 0.7
+                     , vector       >= 0.11 && < 0.14
 
   hs-source-dirs:      src
 


### PR DESCRIPTION
Allows wavefront to successfully build with GHC 9.4